### PR TITLE
Feature/run_all dependencies inicial

### DIFF
--- a/generar_dependencies.py
+++ b/generar_dependencies.py
@@ -1,0 +1,15 @@
+import json
+
+# Crea dependencies.json con contenido estatico
+def generar_dependencies():
+    dependencies = {
+        "adapter": [],
+        "facade": ["adapter"],
+        "mediator": ["adapter", "facade"]
+    }
+
+    with open('dependencies.json', 'w') as f:
+        json.dump(dependencies, f, indent=4)
+
+if __name__ == "__main__":
+    generar_dependencies()

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Crear carpeta de logs si no existe
+mkdir -p ../logs
+
+# Función para registrar el log con fecha y mensaje
+log_message() {
+    echo "[$(date '+%F %T')] $1" >> ../logs/$2.log
+}
+
+# Función para ejecutar Terraform en un módulo
+run_terraform() {
+    MODULE=$1
+    log_message "Iniciando Terraform en el módulo $MODULE" $MODULE
+    cd ../$MODULE
+    terraform init
+    terraform apply -auto-approve
+    log_message "Terraform apply en el módulo $MODULE completado" $MODULE
+    cd ..
+}
+
+# Comprobamos el paso solicitado
+if [ "$1" == "--step" ]; then
+    STEP=$2
+    case $STEP in
+        adapter)
+            run_terraform "adapter"
+            cd $STEP
+            chmod + adapter_parse.sh
+            ./adapter_parse.sh
+            ;;
+        *)
+            echo "Paso desconocido: $STEP"
+            exit 1
+            ;;
+    esac
+else
+    echo "Por favor, especifique el paso usando --step <nombre_del_paso>"
+    exit 1
+fi


### PR DESCRIPTION
Se creo el script `generar_dependencies.py` que crea `dependencies.json` con las dependencias estáticas iniciales:

Se creo el script `scripts/run_all.sh` que orquesta la ejecución de módulos mediante `--step <módulo>`. Por ahora solo soporta el paso **adapter**:
- Entra en `adapter/`, corre terraform init && terraform apply -auto-approve.
- Llama a `adapter_parse.sh` para procesar la salida.
- Registra cada acción en `logs/adapter.log`.

Closes #6 