### PR TITLE
Modificaciones  y ejecuciones en scripts de adapter

### DIFF
--- a/adapter/adapter_parse.sh
+++ b/adapter/adapter_parse.sh
@@ -29,11 +29,11 @@ adapter_status = "$STATUS"
 adapter_code = $CODE
 EOF
 
-# Aca registro la documentación exitosa
-echo "$(date '+%Y-%m-%d %H:%M:%S') | adapter_parse.sh ejecutado correctamente" >> "$LOG"
+# Aca se configura para que haya una ejecuci{on exitosa
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] adapter_parse.sh ejecutado correctamente" >> "$LOG"
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] STATUS: $STATUS CODE:$CODE" >> "$LOG"
 
 if [[ ! -f terraform.tfvars ]]; then
-echo "$(date '+%Y-%m-%d %H:%M:%S') ERROR: terraform.tfvars no fue generado" >> ../logs/adapter.log
-exit 1
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: terraform.tfvars no fue generado" >> ../logs/adapter.log
+    exit 1
 fi
-

--- a/adapter/main.tf
+++ b/adapter/main.tf
@@ -1,10 +1,17 @@
-resource "null_resource" "adapter_exec" {
-  #se crea un recurso nulo dentro de Terraform.
-  provisioner "local-exec" {
-    # especifica que se va a ejecutar un comando local en la maquina de Terraform
-    command = "python3 ${path.module}/adapter_output.py > adapter_output.json"
-    # Ejecuta el script Python, dentro del módulo actual (${path.module}
+variable "adapter_status" {
+  description = "Estado reportado por el adapter"
+  type        = string
+}
 
-  }
+variable "adapter_code" {
+  description = "Código reportado por el adapter"
+  type        = number
+}
 
+output "adapter_status" {
+  value = var.adapter_status
+}
+
+output "adapter_code" {
+  value = var.adapter_code
 }


### PR DESCRIPTION
Agregue los cambios hechos a los archivos adapter/main.tf y adapter/adapter_parse.sh.
En el caso de adapter/adapter_parse.sh hize este cambio  para poder escribir en terraform.tfvars las variables adapter_status y adapter_code. Tambien en el caso de adapter/main.tf, lo hize para poder  leer variables desde terraform.tfvars.
Al final hize sus respectivas ejecuciones en orden y vi que funcionaban correctamente. 