### PR TITLE
Crear archivos bash en las carpetas de Clientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,5 +302,72 @@ y verificas mediante:
 python3 --versión
 ```
 
- 
+## Flujo de los mensajes entre Clientes y  Mediator
+
+1. **cliente_a/send_message.sh** genera `cliente_a/message_a.txt` con el mensaje en formato JSON.
+2. El Mediator (por medio de los scripts `mediator_read.sh` y `mediator_forward.sh`) toma ese archivo y lo copia a `mediator/message_b.txt`.
+3. **cliente_b/recibir_message.sh** lee el archivo `mediator/message_b.txt` y lo imprime en la terminal.
+
+#### Diagrama
+cliente_a/send_message.sh
+        │
+        ▼
+cliente_a/message_a.txt
+        │
+        ▼
+cp cliente_a/message_a.txt mediator/tmp_message.txt
+        │
+        ▼
+mediator/mediator_forward.sh
+        │
+        ▼
+mediator/message_b.txt
+        │
+        ▼
+cliente_b/recibir_message.sh
+
+---
+
+### Ejemplo de prueba aislada
+
+```bash
+# Se ejecuta en cliente_a/
+bash send_messageejecuta.sh "Hola Mediator"
+
+# Se mueve el mensaje al Mediator desde la raiz del proyecto
+
+bash cp cliente_a/message_a.txt mediator/tmp_message.txt
+
+# Desde Mediator/  se ejecuta manualmente el script de mediator
+bash mediator_forward.sh
+
+# Luego se  ejecuta en cliente_b/
+bash recibir_message.sh
+
+Ejemplo de prueba:
+
+### Ejemplo de output
+
+```bash
+# En cliente_a
+bash send_message.sh "Hola Mediators"
+[cliente_a] Mensaje escrito en message_a.txt:
+{"msg": "Hola Mediators", "timestamp": "2025-06-13T21:53:56-04:00"}
+
+# Desde la raíz del proyecto
+cp cliente_a/message_a.txt mediator/tmp_message.txt
+
+# En mediator
+bash mediator/mediator_forward.sh
+[Mediator] Reenviando el mensaje a mediator/message_b.txt...
+[Mediator] Mensaje reenviado exitosamente.
+
+# Contenido en mediator/message_b.txt:
+{"msg": "Hola Mediators", "timestamp": "2025-06-13T21:53:56-04:00"}
+
+# En cliente_b
+bash receive_message.sh
+[cliente_b] Mensaje recibido de ../mediator/message_b.txt:
+{"msg": "Hola Mediators", "timestamp": "2025-06-13T21:53:56-04:00"}
+
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ cliente_a/send_message.sh
 cliente_a/message_a.txt
         │
         ▼
-cp cliente_a/message_a.txt mediator/tmp_message.txt
+cp message_a.txt ../mediator/tmp_message.txt
         │
         ▼
 mediator/mediator_forward.sh
@@ -336,7 +336,7 @@ bash send_messageejecuta.sh "Hola Mediator"
 
 # Se mueve el mensaje al Mediator desde la raiz del proyecto
 
-bash cp cliente_a/message_a.txt mediator/tmp_message.txt
+bash cp message_a.txt ../mediator/tmp_message.txt
 
 # Desde Mediator/  se ejecuta manualmente el script de mediator
 bash mediator_forward.sh
@@ -354,10 +354,10 @@ bash send_message.sh "Hola Mediators"
 [cliente_a] Mensaje escrito en message_a.txt:
 {"msg": "Hola Mediators", "timestamp": "2025-06-13T21:53:56-04:00"}
 
-# Desde la raíz del proyecto
-cp cliente_a/message_a.txt mediator/tmp_message.txt
+# Desde Cliente_a
+cp  message_a.txt ../mediator/tmp_message.txt
 
-# En mediator
+# Desde la raiz
 bash mediator/mediator_forward.sh
 [Mediator] Reenviando el mensaje a mediator/message_b.txt...
 [Mediator] Mensaje reenviado exitosamente.

--- a/cliente_a/send_message.sh
+++ b/cliente_a/send_message.sh
@@ -1,1 +1,14 @@
 #!/bin/bash
+# Script para enviar un mensaje desde cliente_a a través del Mediator
+
+# Mensaje: se puede pasar por argumento o usar variable de entorno
+MSG="${1:-${CLIENT_A_MSG:-'Hola desde cliente A'}}"
+TIMESTAMP="$(date -Iseconds)"
+OUTPUT_FILE="message_a.txt"
+
+# Crear el JSON y escribirlo en message_a.txt
+echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIMESTAMP\"}" > "$OUTPUT_FILE"
+
+echo "[cliente_a] Mensaje escrito en $OUTPUT_FILE:"
+
+cat "$OUTPUT_FILE"

--- a/cliente_a/send_message.sh
+++ b/cliente_a/send_message.sh
@@ -12,4 +12,4 @@ FILE="$DIR/message_a.txt"
 echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIME\"}" > "$FILE"
 
 echo "[cliente_a] Mensaje guardado en $FILE:"
-cat "$FILE"i
+cat "$FILE"

--- a/cliente_a/send_message.sh
+++ b/cliente_a/send_message.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-# Script para enviar un mensaje desde cliente_a a través del Mediator
 
-# Mensaje: se puede pasar por argumento o usar variable de entorno
-MSG="${1:-${CLIENT_A_MSG:-'Hola desde cliente A'}}"
-TIMESTAMP="$(date -Iseconds)"
-OUTPUT_FILE="message_a.txt"
+# Se detecta el directorio donde está el script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Crear el JSON y escribirlo en message_a.txt
-echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIMESTAMP\"}" > "$OUTPUT_FILE"
+# Mensaje por defecto o pasado como argumento
+MSG="${1:-'Hola desde cliente A'}"
+TIME="$(date -Iseconds)"
+FILE="$DIR/message_a.txt"
 
-echo "[cliente_a] Mensaje escrito en $OUTPUT_FILE:"
+# Se guarda el mensaje
+echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIME\"}" > "$FILE"
 
-cat "$OUTPUT_FILE"
+echo "[cliente_a] Mensaje guardado en $FILE:"
+cat "$FILE"i

--- a/cliente_b/receive_message.sh
+++ b/cliente_b/receive_message.sh
@@ -1,1 +1,12 @@
 #!/bin/bash
+# Script para recibir el mensaje reenviado por el Mediator
+
+INPUT_FILE="../mediator/message_b.txt"
+
+if [ ! -f "$INPUT_FILE" ]; then
+echo "[cliente_b] ERROR: No se encontró $INPUT_FILE."
+exit 1
+fi
+
+echo "[cliente_b] Mensaje recibido de $INPUT_FILE:"
+cat "$INPUT_FILE"


### PR DESCRIPTION
Agregue archivos bash en Cliente_a y en Cliente_b: El send_message.sh de Cliente_a, manda un mensaje ( ese mensaje se agrega en un archivo de texto, con fecha y hora  de ejecución). Después se hace interacción con el mediator(copiara el mensaje en un archivo de texto) , el receive_message.sh de Cliente_b finalmente leerá ese archivo y lo hara aparecer en la consola.
Al final también agregue los procedimientos y le flujo al README. 