### PR TITLE
fix/cliente-scripts-mensaje

### DIFF
--- a/cliente_a/send_message.sh
+++ b/cliente_a/send_message.sh
@@ -2,11 +2,12 @@
 
 # Se detecta el directorio donde está el script
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$DIR/.."
 
 # Mensaje por defecto o pasado como argumento
 MSG="${1:-'Hola desde cliente A'}"
 TIME="$(date -Iseconds)"
-FILE="$DIR/message_a.txt"
+FILE="$BASE_DIR/cliente_a/message_a.txt"
 
 # Se guarda el mensaje
 echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIME\"}" > "$FILE"

--- a/cliente_b/receive_message.sh
+++ b/cliente_b/receive_message.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Script para recibir el mensaje reenviado por el Mediator
 
-INPUT_FILE="../mediator/message_b.txt"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$DIR/.."
+
+INPUT_FILE="$BASE_DIR/mediator/message_b.txt"
 
 if [ ! -f "$INPUT_FILE" ]; then
 echo "[cliente_b] ERROR: No se encontró $INPUT_FILE."


### PR DESCRIPTION
Se actualizo la asignación de la variable `BASE_DIR` en los scripts de bash de `send_message.sh` y `receive_message.sh` que asegura que apunte correctamente al directorio padre del script.

```bash
DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
BASE_DIR="$DIR/.."
```
Esta asignación, mejora la legibilidad y reduce posibles errores al calcular rutas relativas, además que este cambio no afecta la lógica general del script, pero mejora su portabilidad y comprensión.

Closes #23 