### PR TITLE
Feature/run_all multistep

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,3 +579,44 @@ $ terraform init
 $ terraform apply -auto-approve
 ```
 Luego de ejecutar terraform, se generarán `tmp_message.sh` y también `message_b.txt`, este último será leído por `cliente_b/`. Dicha función se implementará en el **Sprint 3**.
+
+## Scripts
+
+### `run_all.sh`
+Este script sirve como orquestador general del proyecto, automatizando la ejecución de los distintos módulos Terraform (`adapter`, `facade`, `mediator`, `cliente_a`, `cliente_b`) en el orden correcto y registrando sus resultados.
+
+**Funciones**
+- `log_message(mensaje, módulo)`: Registra un mensaje en el archivo logs/<módulo>.log, añadiendo un timestamp para seguimiento.
+Útil para trazabilidad durante la ejecución de los pasos.
+
+- `run_terraform(módulo, archivo_tfvars)`: Ejecuta terraform init y terraform apply en el módulo indicado. Si se proporciona un archivo .tfvars, lo aplica con sus variables; si no, ejecuta sin parámetros adicionales. También registra en el log correspondiente.
+
+**Pasos definidos (`--step`)**
+- **`adapter`**: Ejecuta el módulo `adapter/` con sus variables definidas. Antes de aplicar Terraform, se ejecuta el script `adapter_parse.sh` para convertir la salida de un script Python en variables legibles por Terraform.
+
+- **`facade`**: Ejecuta el módulo `facade/`, que encapsula la creación de una carpeta (`facade_dir`), un archivo (`facade_file.txt`) y el inicio de un servicio dummy. Registra una línea indicando que se generaron los recursos simulados.
+
+- **`mediator`**: Corre el módulo `mediator/`, el cual actúa como intermediario entre cliente_a y cliente_b. Antes de aplicar, ejecuta `send_message.sh` dentro de `cliente_a/`, simulando el envío de un mensaje. Luego aplica Terraform y se deja constancia en el log.
+
+- **`cliente_a`**: Ejecuta únicamente el script send_message.sh, que escribe un mensaje JSON (`message_a.txt`) que será leído por el mediator.
+
+- **`cliente_b`**: Ejecuta el script `receive_message.sh`, que lee el mensaje reenviado por el mediator y lo muestra en consola.
+
+**Uso general**
+
+```bash
+./run_all.sh --step <nombre_del_paso>
+```
+
+**Ejemplo de ejecución**
+
+```bash
+# Ejecutar el módulo adapter
+./run_all.sh --step adapter
+
+# Ejecutar todos los pasos de forma manual
+./run_all.sh --step facade
+./run_all.sh --step mediator
+./run_all.sh --step cliente_a
+./run_all.sh --step cliente_b
+```

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -1,22 +1,32 @@
 #!/bin/bash
 
+# Se detecta el directorio donde está el script
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$DIR/.."
+
 # Crear carpeta de logs si no existe
-mkdir -p ../logs
+mkdir -p "$BASE_DIR/logs"
 
 # Función para registrar el log con fecha y mensaje
 log_message() {
-    echo "[$(date '+%F %T')] $1" >> ../logs/"$2".log
+    echo "[$(date '+%F %T')] $1" >> "$BASE_DIR/logs/$2.log"
 }
 
 # Función para ejecutar Terraform en un módulo
 run_terraform() {
     MODULE=$1
+    TFVARS=$2
     log_message "Iniciando Terraform en el módulo $MODULE" "$MODULE"
-    cd ../"$MODULE" || exit
+    cd "$BASE_DIR/$MODULE" || exit 0
     terraform init
-    terraform apply -auto-approve
+    if [[ -n "$TFVARS" ]]; then
+        terraform apply -auto-approve -var-file="$TFVARS"
+        log_message "Terraform apply en el módulo $MODULE completado con variables en $TFVARS" "$MODULE"
+    else 
+        terraform apply -auto-approve
     log_message "Terraform apply en el módulo $MODULE completado" "$MODULE"
-    cd ..
+    fi
+    cd "$BASE_DIR" || exit 0
 }
 
 # Comprobamos el paso solicitado
@@ -24,17 +34,42 @@ if [ "$1" == "--step" ]; then
     STEP=$2
     case $STEP in
         adapter)
-            run_terraform "adapter"
-            cd "$STEP" || exit
-            chmod + adapter_parse.sh
-            ./adapter_parse.sh
+            cd "$BASE_DIR/adapter" || exit 0
+            # shellcheck disable=SC1091
+            source "adapter_parse.sh"
+            run_terraform "$STEP" terraform.tfvars
+            ;;
+        facade)
+            run_terraform "$STEP"
+            log_message "Se creo la caperta facade_dir con el archivo facade_file.txt" "$STEP"
+            ;;
+        mediator)
+            cd "$BASE_DIR/cliente_a" || exit 0
+            # shellcheck disable=SC1091 
+            source "send_message.sh" "Se utilizo run_all.sh"
+            run_terraform "$STEP"
+            log_message "Se recepciona el mensaje de A para que B lo reciba" "$STEP"
+            ;;
+        cliente_a)
+            cd "$BASE_DIR/cliente_a" || exit 0
+            # shellcheck disable=SC1091
+            source "send_message.sh" "Se utilizo run_all.sh"
+            cd "$BASE_DIR" || exit 0
+            log_message "El cliente A envio su mensaje" "$STEP"
+            ;;
+        cliente_b)
+            cd "$BASE_DIR/cliente_b" || exit 0
+            # shellcheck disable=SC1091
+            source "receive_message.sh"
+            cd "$BASE_DIR" || exit 0
+            log_message "El cliente B envio recibio su mensaje" "$STEP"
             ;;
         *)
             echo "Paso desconocido: $STEP"
-            exit 1
+            exit 0
             ;;
     esac
 else
     echo "Por favor, especifique el paso usando --step <nombre_del_paso>"
-    exit 1
+    exit 0
 fi


### PR DESCRIPTION
Cambios realizados: 
- Se mejoro la función **run_terraform()** para que pueda recibir el parámetro de variables para *terraform* (util para el modulo `adapter`)
- Se implemento los demás pasos del script `run_all.sh` (**mediator, facade, cliente_a, cliente_b**) para que se pueda automatizar el flujo de trabajo y quede registrado en la carpeta `/logs`.
  **Uso:**
  ```
  # Ejecutar los modulos desde la carpeta raiz

  source scripts/run_all.sh --step adapter
  source scripts/run_all.sh --step facade
  source scripts/run_all.sh --step mediator
  source scripts/run_all.sh --step cliente_a
  source scripts/run_all.sh --step cliente_b
  ```

Closes #20 