### PR TITLE
Feature/generar dependencias

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,3 +579,44 @@ $ terraform init
 $ terraform apply -auto-approve
 ```
 Luego de ejecutar terraform, se generarán `tmp_message.sh` y también `message_b.txt`, este último será leído por `cliente_b/`. Dicha función se implementará en el **Sprint 3**.
+
+## `generar_dependencies.py`
+
+Este archivo, `dependencies.json`, contiene un listado de dependencias entre los módulos de Terraform en el proyecto. Este archivo se utiliza para mantener un registro de las relaciones entre los módulos.
+
+### ¿Como se genera?
+
+El archivo `dependencies.json` es generado automáticamente mediante el script `generar_dependencies.py`, el cual analiza los archivos `.tf` en los módulos `adapter`, `facade`, y `mediator`. El script busca las declaraciones de dependencias dentro de los archivos Terraform y las organiza en el archivo `dependencies.json`.
+
+#### Pasos para generar `dependencies.json`:
+
+Para generar el archivo `dependencies.json`, simplemente ejecuta el siguiente comando en la raíz del proyecto:
+
+```bash
+python3 generar_dependencies.py
+```
+
+#### ¿Qué hace el script?:
+
+- El script recorre las carpetas de los módulos adapter, facade, y mediator.
+- Dentro de cada módulo, busca los archivos main.tf.
+- Extrae las dependencias definidas con las palabras clave depends_on, module, var, y data.
+- Genera el archivo dependencies.json con las dependencias de cada módulo.
+
+#### Ejemplo de salida al ejecutar al final del sprint 02
+
+```json
+{
+    "adapter": [
+        "adapter_status",
+        "adapter_code"
+    ],
+    "facade": [
+        "null_resource.create_folder",
+        "null_resource.create_file"
+    ],
+    "mediator": [
+        "null_resource.mediator_read"
+    ]
+}
+```

--- a/generar_dependencies.py
+++ b/generar_dependencies.py
@@ -1,16 +1,44 @@
 import json
+import os
+import re
 
 
 # Crea dependencies.json con contenido estatico
 def generar_dependencies():
     dependencies = {
         "adapter": [],
-        "facade": ["adapter"],
-        "mediator": ["adapter", "facade"]
+        "facade": [],
+        "mediator": []
     }
+
+    for modulo in ["adapter", "facade", "mediator"]:
+        dependencies[modulo] = obtener_dependencias(modulo)
+
+    print("Archivo dependencies.json generado correctamente.")
 
     with open('dependencies.json', 'w') as f:
         json.dump(dependencies, f, indent=4)
+
+
+def obtener_dependencias(module) -> list:
+    dependencias = []
+
+    patrones = [
+        r'module\s*"([^"]+)"',              # module "nombre"
+        r'depends_on\s*=\s*\[([^\]]+)\]',   # depends_on = [x, y, z]
+        r'var\.([a-zA-Z0-9_-]+)',           # var.nombre_variable
+        r'data\.([a-zA-Z0-9_-]+)',          # data.tipo_recurso
+    ]
+
+    for archivo in os.listdir(module):
+        if archivo.endswith("main.tf"):
+            with open(os.path.join(module, archivo), 'r') as f:
+                contenido = f.read()
+                for patron in patrones:
+                    coincidencias = re.findall(patron, contenido)
+                    dependencias.extend(coincidencias)
+
+    return dependencias
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Se mejoro `generar_dependencies.py` para analizar dinámicamente las dependencias entre módulos y recursos de Terraform, actualizando automáticamente `dependencies.json` con las dependencias detectadas. Se añadieron expresiones regulares para identificar dependencias reales (no solo `adapter` y `facade`), y se eliminan dependencias vacías. 

#### Uso del script
``` bash
# Desde la raíz se ejecuta
python3 generar_dependencies.py
```

Además, se documentó en el README.md de cómo generar y usar `dependencies.json`.

Closes #19 