### PR TITLE
Feature/validacion-logging-mediator

### DIFF
--- a/cliente_a/send_message.sh
+++ b/cliente_a/send_message.sh
@@ -4,10 +4,22 @@
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_DIR="$DIR/.."
 
+FACADE_PATH="$BASE_DIR/facade/facade_dir"
+
+# Verifica si la carpeta, donde se almacenara el mensaje, existe
+if [ ! -d "$FACADE_PATH" ]; then
+    echo "[ERROR] Carpeta facade_dir NO existe."
+fi
+
+# Verifica que la variable de entorno CLIENT_A_MSG exista
+if [[ -z "$CLIENT_A_MSG" ]]; then
+    CLIENT_A_MSG="Luis de inspirate"
+fi
+
 # Mensaje por defecto o pasado como argumento
-MSG="${1:-'Hola desde cliente A'}"
+MSG="$CLIENT_A_MSG"
 TIME="$(date -Iseconds)"
-FILE="$BASE_DIR/cliente_a/message_a.txt"
+FILE="$BASE_DIR/facade/facade_dir/message_a.txt"
 
 # Se guarda el mensaje
 echo "{\"msg\": \"$MSG\", \"timestamp\": \"$TIME\"}" > "$FILE"

--- a/cliente_b/receive_message.sh
+++ b/cliente_b/receive_message.sh
@@ -5,11 +5,13 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE_DIR="$DIR/.."
 
 INPUT_FILE="$BASE_DIR/mediator/message_b.txt"
+OUTPUT_FILE="$DIR/message_b.txt"
 
 if [ ! -f "$INPUT_FILE" ]; then
 echo "[cliente_b] ERROR: No se encontró $INPUT_FILE."
 exit 1
 fi
 
+cp "$INPUT_FILE" "$OUTPUT_FILE"
 echo "[cliente_b] Mensaje recibido de $INPUT_FILE:"
-cat "$INPUT_FILE"
+cat "$OUTPUT_FILE"

--- a/facade/outputs.tf
+++ b/facade/outputs.tf
@@ -7,3 +7,8 @@ output "facade_file" {
   description = "Archivo creado por módulo Facade"
   value       = "${var.facade_dir}/${var.facade_file}"
 }
+
+output "facade_file_path" {
+  description = "Ruta al archivo creado por facade"
+  value       = "${path.module}/facade_dir/facade_file.txt"
+}

--- a/mediator/main.tf
+++ b/mediator/main.tf
@@ -1,6 +1,16 @@
+data "terraform_remote_state" "facade" {
+  backend = "local"
+  config = {
+    path = "../facade/terraform.tfstate"
+  }
+}
+
 resource "null_resource" "mediator_read" {
   provisioner "local-exec" {
     command = "bash ${path.module}/mediator_read.sh"
+    environment = {
+      FACADE_FILE_PATH = data.terraform_remote_state.facade.outputs.facade_file_path
+    }
   }
 }
 

--- a/mediator/mediator_forward.sh
+++ b/mediator/mediator_forward.sh
@@ -2,14 +2,24 @@
 
 TMP_MSG="./tmp_message.txt"
 MSG_B="./message_b.txt"
+LOG_FILE="../logs/mediator.log"
+TS=$(date '+%Y-%m-%d %H:%M:%S')
 
-# Verifica si existe el archivo
-if [ ! -f "$TMP_MSG" ]; then
-  echo "[Mediator] ERROR: No se encontró $TMP_MSG."
+# Llama a mediator_read.sh antes de reenviar el mensaje
+if ! bash ./mediator_read.sh; then
+  echo "[$TS] ERROR: Falló la lectura del mensaje, no se reenvía" >> "$LOG_FILE"
   exit 1
 fi
 
-# Pasa el contenido del archivo temporal a message_b.txt
-echo "[Mediator] Reenviando el mensaje a $MSG_B..."
-cp "$TMP_MSG" "$MSG_B"
-echo "[Mediator] Mensaje reenviado exitosamente."
+# Verifica si existe el archivo
+if [ ! -f "$TMP_MSG" ]; then
+  echo "[$TS] ERROR: No se encontró $TMP_MSG." >> "$LOG_FILE"
+  exit 1
+fi
+
+# Se crea un JSON con el mensaje y timestamp
+cat "$TMP_MSG" > "$MSG_B"
+echo "[$TS] OK: Mensaje reenviado a $MSG_B" >> "$LOG_FILE"
+
+# Limpiando el archivo temporal
+rm -f "$TMP_MSG"

--- a/mediator/mediator_read.sh
+++ b/mediator/mediator_read.sh
@@ -1,16 +1,36 @@
 #!/bin/bash
 
 # Ruta al mensaje de cliente_a
-MSG_A="../cliente_a/message_a.txt"
+MSG_A="../facade/facade_dir/message_a.txt"
 TMP_MSG="./tmp_message.txt"
+LOG_FILE="../logs/mediator.log"
+TS=$(date '+%Y-%m-%d %H:%M:%S')
 
 # Verifica si existe el archivo
 if [ ! -f "$MSG_A" ]; then
-  echo "[Mediator] ERROR: No se encontró $MSG_A"
+  echo "[$TS] ERROR: No se encontró $MSG_A" >> "$LOG_FILE"
+  exit 1
+fi
+
+# Verifica que el archivo tenga la clave "msg"
+if ! grep -q '"msg"' "$MSG_A"; then
+  echo "[$TS] ERROR: $MSG_A no contiene la clave \"msg\"" >> "$LOG_FILE"
+  exit 1
+fi
+
+# Extrae el valor de "msg" usando jq
+if ! command -v jq &>/dev/null; then
+  echo "[$TS] ERROR: 'jq' no está instalado." >> "$LOG_FILE"
+  exit 1
+fi
+
+MSG=$(jq -r '.msg // empty' "$MSG_A")
+if [ -z "$MSG" ] || [ "$MSG" == "null" ]; then
+  echo "[$TS] ERROR: La clave \"msg\" está vacía o inválida en $MSG_A" >> "$LOG_FILE"
   exit 1
 fi
 
 # Copia el contenido de message_a.txt a un archivo temporal tmp_message.txt
-echo "[Mediator] Leyendo mensaje de: cliente_a..."
-cat "$MSG_A" > "$TMP_MSG"
-echo "[Mediator] El mensaje fue leído. Guardado en $TMP_MSG"
+echo "[$TS] Leyendo mensaje de: cliente_a..."
+echo "$MSG" > "$TMP_MSG"
+echo "[$TS] El mensaje fue leído. Guardado en $TMP_MSG" >> "$LOG_FILE"


### PR DESCRIPTION
- El mensaje generado por `cliente_a` ahora se guarda en `facade/facade_dir/message_a.txt` para el intercambio de archivos.
- El `mediator` lee el mensaje desde `facade/facade_dir/message_a.txt`, extrae solo el texto plano y lo guarda como `message_b.txt` en el mismo directorio.
- `cliente_b` copia el mensaje desde `mediator/message_b.txt` a su propio directorio.
- Se actualizaron rutas y scripts bash para mostrar el nuevo flujo de comunicación entre módulos.
- Se añadieron validaciones y logs para los scripts bash en `mediator`.
- El `main.tf` de `mediator` ahora consume los outputs de Facade para rutas dinámicas.